### PR TITLE
Some optimizations

### DIFF
--- a/mods/nv_ships/nodetypes.lua
+++ b/mods/nv_ships/nodetypes.lua
@@ -70,7 +70,7 @@ end
 
 minetest.register_entity("nv_ships:ship_node", {on_step = entity_on_step})
 
-local function register_node_and_entity(name, def)
+local function register_nv_ships_node(name, def)
     local node_def = {
         description = def.description or "",
         drawtype = def.drawtype,
@@ -134,7 +134,7 @@ local function register_hull_node_and_entity(name, def)
             --color = default_palette[n],
             drop = "nv_ships:hull_plate" .. n,
         }
-        register_node_and_entity(name .. n, colored_def)
+        register_nv_ships_node(name .. n, colored_def)
     end
 end
 
@@ -144,7 +144,7 @@ local function register_hull_variants(name, def)
     def2.overlay_tiles = nil
     def2.groups = table.copy(def.groups)
     def2.groups.ship_scaffold = 1
-    register_node_and_entity(name, def2)
+    register_nv_ships_node(name, def2)
     local def3 = table.copy(def)
     def3.tiles = {def.nv_texture .. "_hull.png"}
     def3.overlay_tiles = {def.nv_texture .. "_hull_overlay.png"}
@@ -358,7 +358,7 @@ register_hull_variants("turbo_engine", {
 -- LANDING LEG
 -- A retractable landing leg for spacecraft
 -- Has no entity form
-register_node_and_entity("landing_leg", {
+register_nv_ships_node("landing_leg", {
     description = "Landing leg",
     drawtype = "mesh",
     sunlight_propagates = true,
@@ -383,7 +383,7 @@ register_node_and_entity("landing_leg", {
 -- A glass square cutting a node-shaped space in half
 -- Should be unobtainable
 -- TODO: handle side faces being visible with multiple connected panes
-register_node_and_entity("glass_face", {
+register_nv_ships_node("glass_face", {
     description = "Glass face",
     drawtype = "mesh",
     sunlight_propagates = true,
@@ -412,7 +412,7 @@ register_node_and_entity("glass_face", {
 -- GLASS EDGE
 -- Two perpendicular glass rectangles separating a quadrant of a node
 -- Should be unobtainable
-register_node_and_entity("glass_edge", {
+register_nv_ships_node("glass_edge", {
     description = "Glass edge",
     drawtype = "mesh",
     sunlight_propagates = true,
@@ -443,7 +443,7 @@ register_node_and_entity("glass_edge", {
 -- GLASS VERTEX
 -- Three perpendicular glass squares separating an octant of a node
 -- Should be unobtainable
-register_node_and_entity("glass_vertex", {
+register_nv_ships_node("glass_vertex", {
     description = "Glass vertex",
     drawtype = "mesh",
     sunlight_propagates = true,

--- a/mods/nv_ships/nodetypes.lua
+++ b/mods/nv_ships/nodetypes.lua
@@ -1,6 +1,5 @@
 --[[
-It is in this file that all spaceship nodes are defined. Each node type is associated
-with an entity type, following a simple naming scheme (e.g. "nv_ships:seat" vs "nv_ships:ent_seat").
+It is in this file that all spaceship nodes are defined.
 
  # INDEX
     CALLBACKS
@@ -51,8 +50,6 @@ end
  # COMMON REGISTRATION
 ]]
 
-nv_ships.node_name_to_ent_name_dict = {}
-
 local function colorize_tiles(tiles, overlay_tiles, color)
     local r = {}
     for n=1, #(tiles or {}) do
@@ -70,6 +67,8 @@ local function colorize_tiles(tiles, overlay_tiles, color)
     end
     return r
 end
+
+minetest.register_entity("nv_ships:ship_node", {on_step = entity_on_step})
 
 local function register_node_and_entity(name, def)
     local node_def = {
@@ -95,31 +94,10 @@ local function register_node_and_entity(name, def)
         can_dig = can_dig_normal,
         on_punch = def.on_punch,
         on_rightclick = nv_ships.ship_rightclick_callback,
+        nv_no_entity = def.nv_no_entity
     }
     node_def.groups.nv_ships = 1
     minetest.register_node("nv_ships:" .. name, node_def)
-
-    local ent_use_texture_alpha = false
-    if def.use_texture_alpha == "blend" then
-        ent_use_texture_alpha = true
-    end
-    local ent_def = {
-        initial_properties = {
-            visual = "mesh",
-            textures = def.tiles,
-            use_texture_alpha = ent_use_texture_alpha,
-            visual_size = {x=10, y=10, z=10},
-            mesh = def.mesh
-        },
-        on_step = entity_on_step
-    }
-    minetest.register_entity("nv_ships:ent_" .. name, ent_def)
-
-    if def.nv_no_entity then
-        nv_ships.node_name_to_ent_name_dict["nv_ships:" .. name] = ""
-    else
-        nv_ships.node_name_to_ent_name_dict["nv_ships:" .. name] = "nv_ships:ent_" .. name
-    end
 end
 
 local function register_hull_node_and_entity(name, def)

--- a/mods/nv_ships/ship_convert.lua
+++ b/mods/nv_ships/ship_convert.lua
@@ -47,6 +47,7 @@ function nv_ships.ship_to_entity(ship, player, remove)
         }
         local r = rotation_table[param2]
         r.y = r.y - facing * 90
+
         return r
     end
 
@@ -85,16 +86,65 @@ function nv_ships.ship_to_entity(ship, player, remove)
                     x = x_cockpit_rel, y = y_cockpit_rel, z = z_cockpit_rel
                 })
                 local node_name = ship.An[k]
-                local ent_name = nv_ships.node_name_to_ent_name_dict[node_name]
-                if ent_name ~= nil then
+
+                local def = minetest.registered_nodes[node_name]
+                if def then
                     local pos_abs = {x=x_abs, y=y_abs, z=z_abs}
                     if remove then
                         minetest.remove_node(pos_abs)
                     end
-                    local rotation = to_entity_rotation(ship.A2[k], ship.facing)
-                    if ent_name ~= "" then
-                        local ent = minetest.add_entity(pos_abs, ent_name)
-                        ent:set_attach(player, "", pos_player_rel, rotation, true)
+
+                    local rotation = {x=0, y=0, z=0}
+
+                    if def.paramtype2 == "facedir" then
+                        rotation = to_entity_rotation(ship.A2[k], ship.facing)
+                    end
+
+                    if not def.nv_no_entity then
+                        local use_texture_alpha = (def.use_texture_alpha == "blend")
+
+                        -- “tiles” in node definition and “textures” in entity definition are incompatible
+                        local textures = {}
+
+                        for _, tile in ipairs(def.tiles) do
+                            if type(tile) == "table" then
+                                table.insert(textures, tile.name)
+                            else
+                                table.insert(textures, tile)
+                            end
+                        end
+
+                        if def.drawtype == "mesh" then
+                            local ent = minetest.add_entity(pos_abs, "nv_ships:ship_node")
+                            ent:set_attach(player, "", pos_player_rel, rotation, true)
+
+                            ent:set_properties({
+                                visual = "mesh",
+                                textures = textures,
+                                use_texture_alpha = use_texture_alpha,
+                                visual_size = {x=10, y=10, z=10},
+                                mesh = def.mesh
+                            })
+                        elseif def.drawtype == "cube" then
+                            local ent = minetest.add_entity(pos_abs, "nv_ships:ship_node")
+                            ent:set_attach(player, "", pos_player_rel, rotation, true)
+
+                            -- “cube” uses 6 textures just like a node, but all 6 must be defined
+                            if #textures ~= 6 then
+                                local last = #textures
+
+                                for idx = last + 1, 6 do
+                                    textures[idx] = textures[last]
+                                end
+                            end
+
+                            ent:set_properties({
+                                visual = "cube",
+                                textures = textures,
+                                use_texture_alpha = use_texture_alpha,
+                                visual_size = {x=10, y=10, z=10}
+                            })
+                        end
                     end
                 end
                 k = k + 1

--- a/mods/nv_ships/ship_convert.lua
+++ b/mods/nv_ships/ship_convert.lua
@@ -125,7 +125,7 @@ function nv_ships.ship_to_entity(ship, player, remove)
                                 visual_size = {x=10, y=10, z=10},
                                 mesh = def.mesh
                             })
-                        elseif def.drawtype == "cube" then
+                        elseif def.drawtype == "normal" then
                             local ent = minetest.add_entity(pos_abs, "nv_ships:ship_node")
                             ent:set_attach(player, "", pos_player_rel, rotation, true)
 


### PR DESCRIPTION
Register just one entity “nv_ships:ship_node” for all ship nodes instead of one entity “nv_ships:ent_…” per “nv_ships” node, so that is now possible to attach to ship arbitrary node with `normal` or `mesh` drawtype.