### PR TITLE
Add support for async/parallel mapgen API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.4.2] - unreleased
+### Performance
+ - Added support for the new async mapgen API in Minetest 5.9, with fallback for older versions.
+
 ## [0.4.1] - 28-12-2023
 ### Fixed
  - Erratic jumps after landing a ship for the second time.

--- a/mods/nv_flora/init.lua
+++ b/mods/nv_flora/init.lua
@@ -23,6 +23,8 @@ dofile(minetest.get_modpath("nv_flora") .. "/nodetypes.lua")
 
 if minetest.register_mapgen_script then
     minetest.register_mapgen_script(minetest.get_modpath("nv_flora") .. "/mapgen.lua")
+else
+    dofile(minetest.get_modpath("nv_flora") .. "/mapgen.lua")
 end
 
 function get_planet_plant_colors(seed)

--- a/mods/nv_flora/mapgen.lua
+++ b/mods/nv_flora/mapgen.lua
@@ -1,14 +1,3 @@
---[[
-NV Flora implements large flora for Nodeverse.
-
-Included files:
-    nodetypes.lua       Node definitions and registration
-    thumbnail.lua       Utility functions to build a thumbnail for each plant
-    other               Each file contains definitions for one kind of plant
-
- # INDEX
-]]--
-
 nv_flora = {}
 
 dofile(minetest.get_modpath("nv_flora") .. "/thumbnail.lua")
@@ -19,11 +8,10 @@ dofile(minetest.get_modpath("nv_flora") .. "/trees.lua")
 dofile(minetest.get_modpath("nv_flora") .. "/branched_plants.lua")
 dofile(minetest.get_modpath("nv_flora") .. "/vines.lua")
 dofile(minetest.get_modpath("nv_flora") .. "/lilypads.lua")
-dofile(minetest.get_modpath("nv_flora") .. "/nodetypes.lua")
 
-if minetest.register_mapgen_script then
-    minetest.register_mapgen_script(minetest.get_modpath("nv_flora") .. "/mapgen.lua")
-end
+local f = io.open(minetest.get_worldpath() .. "/nv_flora.node_types", "rt")
+nv_flora.node_types = minetest.deserialize(f:read())
+f:close()
 
 function get_planet_plant_colors(seed)
     local G = PcgRandom(seed, seed)
@@ -123,3 +111,5 @@ local function plant_handler(seed)
 end
 
 nv_flora.get_planet_flora = plant_handler
+
+nv_planetgen.register_structure_handler(plant_handler)

--- a/mods/nv_flora/mapgen.lua
+++ b/mods/nv_flora/mapgen.lua
@@ -1,4 +1,6 @@
-nv_flora = {}
+if minetest.save_gen_notify then
+    nv_flora = {}
+end
 
 dofile(minetest.get_modpath("nv_flora") .. "/thumbnail.lua")
 dofile(minetest.get_modpath("nv_flora") .. "/small_plants.lua")

--- a/mods/nv_flora/nodetypes.lua
+++ b/mods/nv_flora/nodetypes.lua
@@ -717,3 +717,4 @@ function nv_flora.register_all_nodes()
 end
 
 nv_flora.register_all_nodes()
+minetest.safe_file_write(minetest.get_worldpath() .. "/nv_flora.node_types", minetest.serialize(nv_flora.node_types))

--- a/mods/nv_game/init.lua
+++ b/mods/nv_game/init.lua
@@ -10,9 +10,6 @@ on other NV mods.
 
 dofile(minetest.get_modpath("nv_game") .. "/nodetypes.lua")
 
--- Remove default starting planet
-nv_planetgen.remove_planet_mapping(1)
-
 --[[
  # SHIPS SETUP
 ]]

--- a/mods/nv_planetgen/api.lua
+++ b/mods/nv_planetgen/api.lua
@@ -101,8 +101,10 @@ local function mapgen_callback(minp, maxp, blockseed)
     end
 end
 
-minetest.register_on_generated(mapgen_callback)
-minetest.set_gen_notify({custom = true}, {}, {"nv_planetgen:meta_nodes"})
+if minetest.register_mapgen_script then
+    minetest.register_on_generated(mapgen_callback)
+    minetest.set_gen_notify({custom = true}, {}, {"nv_planetgen:meta_nodes"})
+end
 
 --[[
 # INITIALIZATION

--- a/mods/nv_planetgen/api.lua
+++ b/mods/nv_planetgen/api.lua
@@ -168,3 +168,5 @@ Here, add random texture rotation around Y axis to dummy stone block
 nv_planetgen.color_multiplier = {}
 
 nv_planetgen.register_all_nodes()
+minetest.safe_file_write(minetest.get_worldpath() .. "/nv_planetgen.random_yrot_nodes", minetest.serialize(nv_planetgen.random_yrot_nodes))
+minetest.safe_file_write(minetest.get_worldpath() .. "/nv_planetgen.color_multiplier", minetest.serialize(nv_planetgen.color_multiplier))

--- a/mods/nv_planetgen/api.lua
+++ b/mods/nv_planetgen/api.lua
@@ -79,39 +79,6 @@ function nv_planetgen.remove_planet_mapping(index)
 end
 
 --[[
-Contains a list of all node metadata to add in the next emerge. Entry format is:
-    pos         node position
-    meta        metadata, as table
-]]--
-local meta_nodes = {}
-
--- API
-function nv_planetgen.set_meta(pos, meta)
-    table.insert(meta_nodes, {
-        pos = pos,
-        meta = meta,
-    })
-end
-
-local registered_structures = {}
-local function register_structure(seed, def)
-    registered_structures[seed] = registered_structures[seed] or {}
-    for n, structure in ipairs(registered_structures[seed]) do
-        if structure.order > def.order then
-            table.insert(registered_structures[seed], n, def)
-            break
-        end
-    end
-    table.insert(registered_structures[seed], def)
-end
-
-local structure_handlers = {}
--- The callback will get a seed and must return a list of structures
-function nv_planetgen.register_structure_handler(callback)
-    table.insert(structure_handlers, callback)
-end
-
---[[
 # INITIALIZATION
 ]]--
 

--- a/mods/nv_planetgen/api.lua
+++ b/mods/nv_planetgen/api.lua
@@ -27,6 +27,11 @@ and the same region on a planet with some seed. Entry format is:
 ]]--
 nv_planetgen.planet_mappings = {}
 local planet_mappings = nv_planetgen.planet_mappings
+local f = io.open(minetest.get_worldpath() .. "/nv_planetgen.planet_mappings", "rt")
+if f then
+    planet_mappings = minetest.deserialize(f:read())
+    f:close()
+end
 minetest.safe_file_write(minetest.get_worldpath() .. "/nv_planetgen.planet_mappings", minetest.serialize(planet_mappings))
 
 --[[
@@ -34,6 +39,11 @@ Maps planet IDs (keys) to actual planet metadata tables (values).
 ]]--
 nv_planetgen.planet_dictionary = {}
 local planet_dictionary = nv_planetgen.planet_dictionary
+f = io.open(minetest.get_worldpath() .. "/nv_planetgen.planet_dictionary", "rt")
+if f then
+    planet_dictionary = minetest.deserialize(f:read())
+    f:close()
+end
 minetest.safe_file_write(minetest.get_worldpath() .. "/nv_planetgen.planet_dictionary", minetest.serialize(planet_dictionary))
 
 function nv_planetgen.clear_planet_mapping_area(mapping)

--- a/mods/nv_planetgen/api.lua
+++ b/mods/nv_planetgen/api.lua
@@ -1,0 +1,170 @@
+--[[
+This is the regular environment API to the map generator.
+Included files:
+    util.lua            Probability distribution and math functions
+    meta.lua            Generates global characteristics of a planet from a seed
+    nodetypes.lua       Registers custom nodes for a new planet
+
+ # INDEX
+    INITIALIZATION
+--]]
+
+-- Namespace for all the API functions
+nv_planetgen = {}
+
+dofile(minetest.get_modpath("nv_planetgen") .. "/util.lua")
+dofile(minetest.get_modpath("nv_planetgen") .. "/meta.lua")
+dofile(minetest.get_modpath("nv_planetgen") .. "/nodetypes.lua")
+
+--[[
+Contains a list of all current mappings between chunk coordinate rectangles
+and the same region on a planet with some seed. Entry format is:
+    minp        starting x, y and z node coordinates
+    maxp        ending x, y and z node coordinates
+    offset      world position P will map to planet coordinates P + offset
+    seed        planet seed; each seed represents a unique planet
+    walled      (optional) builds stone walls around the mapped area
+]]--
+nv_planetgen.planet_mappings = {}
+local planet_mappings = nv_planetgen.planet_mappings
+minetest.set_mapgen_setting("nv_planetgen.planet_mappings", minetest.serialize(planet_mappings))
+
+--[[
+Maps planet IDs (keys) to actual planet metadata tables (values).
+]]--
+nv_planetgen.planet_dictionary = {}
+local planet_dictionary = nv_planetgen.planet_dictionary
+minetest.set_mapgen_setting("nv_planetgen.planet_dictionary", minetest.serialize(planet_dictionary))
+
+function nv_planetgen.clear_planet_mapping_area(mapping)
+    local minp = {x=mapping.minp.x, y=mapping.minp.y, z=mapping.minp.z}
+    local maxp = {x=mapping.maxp.x, y=mapping.maxp.y, z=mapping.maxp.z}
+    minetest.delete_area(minp, maxp)
+end
+
+local function planet_from_mapping(mapping)
+    local planet = planet_dictionary[mapping.seed]
+    if planet == nil then
+        planet = generate_planet_metadata(mapping.seed)
+        nv_planetgen.choose_planet_nodes_and_colors(planet)
+        planet_dictionary[mapping.seed] = planet
+        minetest.set_mapgen_setting("nv_planetgen.planet_dictionary", minetest.serialize(planet_dictionary))
+        planet.seed = mapping.seed
+        planet.num_mappings = 1
+    else
+        planet.num_mappings = planet.num_mappings + 1
+    end
+    return planet
+end
+
+-- API
+function nv_planetgen.add_planet_mapping(mapping)
+    table.insert(planet_mappings, mapping)
+    planet_from_mapping(mapping) -- Memoize and pass to mapgen env
+    minetest.set_mapgen_setting("nv_planetgen.planet_mappings", minetest.serialize(planet_mappings))
+    return #planet_mappings
+end
+
+-- API
+function nv_planetgen.remove_planet_mapping(index)
+    local mapping = planet_mappings[index]
+    local planet = planet_from_mapping(mapping)
+    planet.num_mappings = planet.num_mappings - 1
+    if planet.num_mappings == 0 then
+        planet_dictionary[planet_mappings[index].seed] = nil
+        minetest.set_mapgen_setting("nv_planetgen.planet_dictionary", minetest.serialize(planet_dictionary))
+    end
+    minetest.set_mapgen_setting("nv_planetgen.planet_mappings", minetest.serialize(planet_mappings))
+    table.remove(planet_mappings, index)
+end
+
+--[[
+Contains a list of all node metadata to add in the next emerge. Entry format is:
+    pos         node position
+    meta        metadata, as table
+]]--
+local meta_nodes = {}
+
+-- API
+function nv_planetgen.set_meta(pos, meta)
+    table.insert(meta_nodes, {
+        pos = pos,
+        meta = meta,
+    })
+end
+
+local registered_structures = {}
+local function register_structure(seed, def)
+    registered_structures[seed] = registered_structures[seed] or {}
+    for n, structure in ipairs(registered_structures[seed]) do
+        if structure.order > def.order then
+            table.insert(registered_structures[seed], n, def)
+            break
+        end
+    end
+    table.insert(registered_structures[seed], def)
+end
+
+local structure_handlers = {}
+-- The callback will get a seed and must return a list of structures
+function nv_planetgen.register_structure_handler(callback)
+    table.insert(structure_handlers, callback)
+end
+
+--[[
+# INITIALIZATION
+]]--
+
+-- Nodes defined only to avoid errors from mapgens
+
+minetest.register_node('nv_planetgen:stone', {
+    drawtype = "normal",
+    visual_scale = 1.0,
+    tiles = {
+        "nv_stone.png"
+    },
+    paramtype2 = "facedir",
+    place_param2 = 8,
+})
+minetest.register_alias('mapgen_stone', 'nv_planetgen:stone')
+
+minetest.register_node('nv_planetgen:water_source', {
+    drawtype = "liquid",
+    visual_scale = 1.0,
+    tiles = {
+        "nv_water.png"
+    },
+    paramtype2 = "facedir",
+    place_param2 = 8,
+})
+minetest.register_alias('mapgen_water_source', 'nv_planetgen:water_source')
+
+--[[
+Dictionary, maps node IDs to random texture rotation modulo.
+See 'pass_final.lua'. Sensible values are:
+    nil     No entry, random rotation disabled
+    1       Effectively equivalent to 'nil'
+    2       Rotate some blocks 90 deg around +Y vector
+    4       Rotate all blocks a random multiple of 90 deg around +Y vector
+    24      Rotate all blocks randomly around all axes
+Here, add random texture rotation around Y axis to dummy stone block
+]]--
+
+nv_planetgen.random_yrot_nodes = {
+    [minetest.get_content_id('nv_planetgen:stone')] = 4
+}
+
+--[[
+Dictionary, maps node IDs to color param2 multiplier.
+See 'pass_final.lua'. Sensible values are:
+    nil     No entry, equivalent to 1
+    1       Useful for param2 = 'color'
+    4       Useful for param2 = 'color4dir'
+    8       Useful for param2 = 'colorwallmounted'
+    32      Useful for param2 = 'colorfacedir' or 'colordegrotate'
+Here, add random texture rotation around Y axis to dummy stone block
+]]--
+
+nv_planetgen.color_multiplier = {}
+
+nv_planetgen.register_all_nodes()

--- a/mods/nv_planetgen/api.lua
+++ b/mods/nv_planetgen/api.lua
@@ -88,6 +88,22 @@ function nv_planetgen.remove_planet_mapping(index)
     table.remove(planet_mappings, index)
 end
 
+local function mapgen_callback(minp, maxp, blockseed)
+    local GN = minetest.get_mapgen_object("gennotify")
+    local meta_nodes = GN["custom"]["nv_planetgen:meta_nodes"]
+    for n, entry in ipairs(meta_nodes) do
+        local meta = minetest.get_meta(entry.pos)
+        local tab = meta:to_table()
+        for k, v in pairs(entry.meta.fields) do
+            tab.fields[k] = v
+        end
+        meta:from_table(tab)
+    end
+end
+
+minetest.register_on_generated(mapgen_callback)
+minetest.set_gen_notify({custom = true}, {}, {"nv_planetgen:meta_nodes"})
+
 --[[
 # INITIALIZATION
 ]]--

--- a/mods/nv_planetgen/api.lua
+++ b/mods/nv_planetgen/api.lua
@@ -27,14 +27,14 @@ and the same region on a planet with some seed. Entry format is:
 ]]--
 nv_planetgen.planet_mappings = {}
 local planet_mappings = nv_planetgen.planet_mappings
-minetest.set_mapgen_setting("nv_planetgen.planet_mappings", minetest.serialize(planet_mappings))
+minetest.safe_file_write(minetest.get_worldpath() .. "/nv_planetgen.planet_mappings", minetest.serialize(planet_mappings))
 
 --[[
 Maps planet IDs (keys) to actual planet metadata tables (values).
 ]]--
 nv_planetgen.planet_dictionary = {}
 local planet_dictionary = nv_planetgen.planet_dictionary
-minetest.set_mapgen_setting("nv_planetgen.planet_dictionary", minetest.serialize(planet_dictionary))
+minetest.safe_file_write(minetest.get_worldpath() .. "/nv_planetgen.planet_dictionary", minetest.serialize(planet_dictionary))
 
 function nv_planetgen.clear_planet_mapping_area(mapping)
     local minp = {x=mapping.minp.x, y=mapping.minp.y, z=mapping.minp.z}
@@ -48,7 +48,7 @@ local function planet_from_mapping(mapping)
         planet = generate_planet_metadata(mapping.seed)
         nv_planetgen.choose_planet_nodes_and_colors(planet)
         planet_dictionary[mapping.seed] = planet
-        minetest.set_mapgen_setting("nv_planetgen.planet_dictionary", minetest.serialize(planet_dictionary))
+        minetest.safe_file_write(minetest.get_worldpath() .. "/nv_planetgen.planet_dictionary", minetest.serialize(planet_dictionary))
         planet.seed = mapping.seed
         planet.num_mappings = 1
     else
@@ -61,7 +61,7 @@ end
 function nv_planetgen.add_planet_mapping(mapping)
     table.insert(planet_mappings, mapping)
     planet_from_mapping(mapping) -- Memoize and pass to mapgen env
-    minetest.set_mapgen_setting("nv_planetgen.planet_mappings", minetest.serialize(planet_mappings))
+    minetest.safe_file_write(minetest.get_worldpath() .. "/nv_planetgen.planet_mappings", minetest.serialize(planet_mappings))
     return #planet_mappings
 end
 
@@ -72,9 +72,9 @@ function nv_planetgen.remove_planet_mapping(index)
     planet.num_mappings = planet.num_mappings - 1
     if planet.num_mappings == 0 then
         planet_dictionary[planet_mappings[index].seed] = nil
-        minetest.set_mapgen_setting("nv_planetgen.planet_dictionary", minetest.serialize(planet_dictionary))
+        minetest.safe_file_write(minetest.get_worldpath() .. "/nv_planetgen.planet_dictionary", minetest.serialize(planet_dictionary))
     end
-    minetest.set_mapgen_setting("nv_planetgen.planet_mappings", minetest.serialize(planet_mappings))
+    minetest.safe_file_write(minetest.get_worldpath() .. "/nv_planetgen.planet_mappings", minetest.serialize(planet_mappings))
     table.remove(planet_mappings, index)
 end
 

--- a/mods/nv_planetgen/init.lua
+++ b/mods/nv_planetgen/init.lua
@@ -15,11 +15,13 @@ a list of all tags in order.
 
  # INDEX
     API REFERENCE
-    GAME SETUP
     EXAMPLES
 ]]--
 
-dofile(minetest.get_modpath("nv_planetgen") .. "/mapgen.lua")
+dofile(minetest.get_modpath("nv_planetgen") .. "/api.lua")
+if minetest.register_mapgen_script then
+    minetest.register_mapgen_script(minetest.get_modpath("nv_planetgen") .. "/mapgen.lua")
+end
 
 --[[
 # API REFERENCE
@@ -106,106 +108,6 @@ Must be called when generating custom terrain directly via the 'on not
 generated' callback. It is not necessary to call it if the new area is generated
 using 'nv_planetgen.generate_planet_chunk()' or if no terrain is generated.
 ]]
-
---[[
-# GAME SETUP
-
-Default game setup:
-An infinite cloud of floating planets.
-]]
-
-local block_size = 300
-local planets_per_block = 4
-local planet_size = 60
-
-local function new_area_callback(minp, maxp, area, A, A1, A2)
-    local max = math.max
-    local min = math.min
-    local ceil = math.ceil
-    local floor = math.floor
-    local minpx, minpy, minpz = minp.x, minp.y, minp.z
-    local maxpx, maxpy, maxpz = maxp.x, maxp.y, maxp.z
-    -- Iterate over all overlapping block_size * block_size * block_size blocks
-    for block_x=minpx - minpx%block_size, maxpx - maxpx%block_size, block_size do
-        for block_y=minpy - minpy%block_size, maxpy - maxpy%block_size, block_size do
-            for block_z=minpz - minpz%block_size, maxpz - maxpz%block_size, block_size do
-                -- Get overlapping area
-                local common_minp = {
-                    x=max(minpx, block_x),
-                    y=max(minpy, block_y),
-                    z=max(minpz, block_z)
-                }
-                local common_maxp = {
-                    x=min(maxpx, block_x + block_size - 1),
-                    y=min(maxpy, block_y + block_size - 1),
-                    z=min(maxpz, block_z + block_size - 1)
-                }
-                -- Check overlap with randomly placed planets
-                local seed = block_x + 0x10*block_y + 0x1000*block_z
-                local G = PcgRandom(seed, seed)
-                for n=1, planets_per_block do
-                    local planet_pos = {
-                        x=block_x + G:next(ceil(planet_size/2), block_size - ceil(planet_size/2)),
-                        y=block_y + G:next(ceil(planet_size/2), block_size - ceil(planet_size/2)),
-                        z=block_z + G:next(ceil(planet_size/2), block_size - ceil(planet_size/2))
-                    }
-                    local planet_mapping = {
-                        minp = {
-                            x=planet_pos.x - floor(planet_size/2),
-                            y=planet_pos.y - 4*floor(planet_size/2),
-                            z=planet_pos.z - floor(planet_size/2),
-                        },
-                        maxp = {
-                            x=planet_pos.x + floor(planet_size/2),
-                            y=planet_pos.y + 4*floor(planet_size/2),
-                            z=planet_pos.z + floor(planet_size/2),
-                        }
-                    }
-                    local common_minp2 = {
-                        x=max(common_minp.x, planet_mapping.minp.x),
-                        y=max(common_minp.y, planet_mapping.minp.y),
-                        z=max(common_minp.z, planet_mapping.minp.z)
-                    }
-                    local common_maxp2 = {
-                        x=min(common_maxp.x, planet_mapping.maxp.x),
-                        y=min(common_maxp.y, planet_mapping.maxp.y),
-                        z=min(common_maxp.z, planet_mapping.maxp.z)
-                    }
-                    if common_maxp2.x > common_minp2.x
-                    and common_maxp2.y > common_minp2.y
-                    and common_maxp2.z > common_minp2.z then
-                        -- Generate planet
-                        planet_mapping.offset = {x=0, y=-planet_pos.y, z=0}
-                        planet_mapping.seed = seed + n
-                        planet_mapping.walled = true
-                        nv_planetgen.generate_planet_chunk(
-                            common_minp2, common_maxp2, area, A, A1, A2, planet_mapping
-                        )
-                    end
-                end
-            end
-        end
-    end
-end
-
-nv_planetgen.register_on_not_generated(new_area_callback)
-
--- Add starting planet
-nv_planetgen.add_planet_mapping {
-    minp = {
-        x=-math.floor(planet_size/2),
-        y=-2*planet_size,
-        z=-math.floor(planet_size/2)
-    },
-    maxp = {
-        x=math.floor(planet_size/2),
-        y=2*planet_size,
-        z=math.floor(planet_size/2)
-    },
-    offset = {x=0, y=0, z=0},
-    seed = 0,
-    walled = true
-}
 
 --[[
 # EXAMPLES

--- a/mods/nv_planetgen/init.lua
+++ b/mods/nv_planetgen/init.lua
@@ -21,6 +21,8 @@ a list of all tags in order.
 dofile(minetest.get_modpath("nv_planetgen") .. "/api.lua")
 if minetest.register_mapgen_script then
     minetest.register_mapgen_script(minetest.get_modpath("nv_planetgen") .. "/mapgen.lua")
+else
+    dofile(minetest.get_modpath("nv_planetgen") .. "/mapgen.lua")
 end
 
 --[[

--- a/mods/nv_planetgen/mapgen.lua
+++ b/mods/nv_planetgen/mapgen.lua
@@ -148,6 +148,41 @@ local function split_not_generated_boxes(not_generated_boxes, minp, maxp)
     return r
 end
 
+local registered_structures = nv_planetgen.registered_structures
+
+-- API
+function nv_planetgen.register_structure(seed, def)
+    registered_structures[seed] = registered_structures[seed] or {}
+    for n, structure in ipairs(registered_structures[seed]) do
+        if structure.order > def.order then
+            table.insert(registered_structures[seed], n, def)
+            break
+        end
+    end
+    table.insert(registered_structures[seed], def)
+end
+
+local structure_handlers = nv_planetgen.structure_handlers
+-- The callback will get a seed and must return a list of structures
+function nv_planetgen.register_structure_handler(callback)
+    table.insert(structure_handlers, callback)
+end
+
+--[[
+Contains a list of all node metadata to add in the next emerge. Entry format is:
+    pos         node position
+    meta        metadata, as table
+]]--
+local meta_nodes = {}
+
+-- API
+function nv_planetgen.set_meta(pos, meta)
+    table.insert(meta_nodes, {
+        pos = pos,
+        meta = meta,
+    })
+end
+
 --[[
 # ENTRY POINT
 ]]--

--- a/mods/nv_planetgen/mapgen.lua
+++ b/mods/nv_planetgen/mapgen.lua
@@ -237,17 +237,8 @@ local function mapgen_callback(VM, minp, maxp, blockseed)
 end
 
 function nv_planetgen.refresh_meta()
-    return
-    -- TODO: implement using gennotify
-    --[[for n, entry in ipairs(meta_nodes) do
-        local meta = minetest.get_meta(entry.pos)
-        local tab = meta:to_table()
-        for k, v in pairs(entry.meta.fields) do
-            tab.fields[k] = v
-        end
-        meta:from_table(tab)
-    end
-    meta_nodes = {}]]--
+    minetest.save_gen_notify("nv_planetgen:meta_nodes", meta_nodes)
+    meta_nodes = {}
 end
 
 --[[

--- a/mods/nv_planetgen/mapgen.lua
+++ b/mods/nv_planetgen/mapgen.lua
@@ -1,9 +1,8 @@
 --[[
-This is the main file for the map generator.
+This is the main file for the map generator. It should be run in a mapgen environment.
 Included files:
     util.lua            Probability distribution and math functions
     meta.lua            Generates global characteristics of a planet from a seed
-    nodetypes.lua       Registers custom nodes for a new planet
     pass_elevation.lua  First pass: terrain elevation and layers, oceans
     pass_caves.lua      Second pass: caves
     pass_structures.lua Third pass: trees and other structures
@@ -14,86 +13,32 @@ Included files:
     INITIALIZATION
 --]]
 
--- Namespace for all the API functions
 nv_planetgen = {}
 
 dofile(minetest.get_modpath("nv_planetgen") .. "/util.lua")
 dofile(minetest.get_modpath("nv_planetgen") .. "/meta.lua")
-dofile(minetest.get_modpath("nv_planetgen") .. "/nodetypes.lua")
 dofile(minetest.get_modpath("nv_planetgen") .. "/pass_elevation.lua")
 dofile(minetest.get_modpath("nv_planetgen") .. "/pass_caves.lua")
 dofile(minetest.get_modpath("nv_planetgen") .. "/pass_structures.lua")
 dofile(minetest.get_modpath("nv_planetgen") .. "/pass_final.lua")
 
---[[
-Contains a list of all current mappings between chunk coordinate rectangles
-and the same region on a planet with some seed. Entry format is:
-    minp        starting x, y and z node coordinates
-    maxp        ending x, y and z node coordinates
-    offset      world position P will map to planet coordinates P + offset
-    seed        planet seed; each seed represents a unique planet
-    walled      (optional) builds stone walls around the mapped area
-]]--
-nv_planetgen.planet_mappings = {}
-local planet_mappings = nv_planetgen.planet_mappings
-
---[[
-Maps planet IDs (keys) to actual planet metadata tables (values).
-]]--
-nv_planetgen.planet_dictionary = {}
-local planet_dictionary = nv_planetgen.planet_dictionary
-
-local function clear_planet_mapping_area(mapping)
-    local minp = {x=mapping.minp.x, y=mapping.minp.y, z=mapping.minp.z}
-    local maxp = {x=mapping.maxp.x, y=mapping.maxp.y, z=mapping.maxp.z}
-    minetest.delete_area(minp, maxp)
-end
-
-local function planet_from_mapping(mapping)
-    local planet = planet_dictionary[mapping.seed]
-    if planet == nil then
-        planet = generate_planet_metadata(mapping.seed)
-        nv_planetgen.choose_planet_nodes_and_colors(planet)
-        planet_dictionary[mapping.seed] = planet
-        planet.seed = mapping.seed
-        planet.num_mappings = 1
-    else
-        planet.num_mappings = planet.num_mappings + 1
-    end
-    return planet
-end
-
--- API
-function nv_planetgen.add_planet_mapping(mapping)
-    table.insert(planet_mappings, mapping)
-    return #planet_mappings
-end
-
--- API
-function nv_planetgen.remove_planet_mapping(index)
-    local mapping = planet_mappings[index]
-    local planet = planet_from_mapping(mapping)
-    planet.num_mappings = planet.num_mappings - 1
-    if planet.num_mappings == 0 then
-        planet_dictionary[planet_mappings[index].seed] = nil
-    end
-    table.remove(planet_mappings, index)
-end
-
 local generator_dirty_flag = false
 
--- API
 function nv_planetgen.set_dirty_flag()
     generator_dirty_flag = true
 end
 
--- API
 local post_processing = {}
 function nv_planetgen.register_post_processing(callback)
     table.insert(post_processing, callback)
 end
 
--- API
+local function planet_from_mapping(mapping)
+    local planet_dictionary = minetest.deserialize(minetest.get_mapgen_setting("nv_planetgen.planet_dictionary"))
+    local planet = planet_dictionary[mapping.seed]
+    return planet
+end
+
 function nv_planetgen.generate_planet_chunk(minp, maxp, area, A, A1, A2, mapping)
     local max = math.max
     local min = math.min
@@ -201,38 +146,16 @@ local function split_not_generated_boxes(not_generated_boxes, minp, maxp)
     return r
 end
 
-local on_not_generated_callback = nil
-
--- API
-function nv_planetgen.register_on_not_generated(callback)
-    on_not_generated_callback = callback
-end
-
---[[
-Contains a list of all node metadata to add in the next emerge. Entry format is:
-    pos         node position
-    meta        metadata, as table
-]]--
-local meta_nodes = {}
-
--- API
-function nv_planetgen.set_meta(pos, meta)
-    table.insert(meta_nodes, {
-        pos = pos,
-        meta = meta,
-    })
-end
-
 --[[
 # ENTRY POINT
 ]]--
 
 local A, A1, A2 = nil, nil, nil
 
-local function mapgen_callback(minp, maxp, blockseed)
+local function mapgen_callback(VM, minp, maxp, blockseed)
     local max = math.max
     local min = math.min
-    local VM, emin, emax = minetest.get_mapgen_object("voxelmanip")
+    local emin, emax = VM:get_emerged_area()
     local area = VoxelArea:new{MinEdge=emin, MaxEdge=emax}
     if A == nil then
         A = VM:get_data()
@@ -247,6 +170,7 @@ local function mapgen_callback(minp, maxp, blockseed)
     local not_generated_boxes = {{minp = minp, maxp = maxp}}
 
     -- Find mapping(s) for the generated region
+    local planet_mappings = minetest.deserialize(minetest.get_mapgen_setting("nv_planetgen.planet_mappings"))
     for key, mapping in pairs(planet_mappings) do
         local commonmin = {
             x=max(minp.x, mapping.minp.x),
@@ -263,24 +187,20 @@ local function mapgen_callback(minp, maxp, blockseed)
             not_generated_boxes = split_not_generated_boxes(not_generated_boxes, commonmin, commonmax)
         end
     end
-    if on_not_generated_callback ~= nil then
-        for index, box in ipairs(not_generated_boxes) do
-            on_not_generated_callback(box.minp, box.maxp, area, A, A1, A2)
-        end
-    end
     if generator_dirty_flag then
         generator_dirty_flag = false
         VM:set_data(A)
         VM:set_light_data(A1)
         VM:set_param2_data(A2)
         VM:calc_lighting()
-        VM:write_to_map()
     end
     nv_planetgen.refresh_meta()
 end
 
 function nv_planetgen.refresh_meta()
-    for n, entry in ipairs(meta_nodes) do
+    return
+    -- TODO: implement using gennotify
+    --[[for n, entry in ipairs(meta_nodes) do
         local meta = minetest.get_meta(entry.pos)
         local tab = meta:to_table()
         for k, v in pairs(entry.meta.fields) do
@@ -288,7 +208,7 @@ function nv_planetgen.refresh_meta()
         end
         meta:from_table(tab)
     end
-    meta_nodes = {}
+    meta_nodes = {}]]--
 end
 
 --[[
@@ -296,59 +216,3 @@ end
 ]]--
 
 minetest.register_on_generated(mapgen_callback)
-
-nv_planetgen.register_on_not_generated(nil)
-
--- Nodes defined only to avoid errors from mapgens
-
-minetest.register_node('nv_planetgen:stone', {
-    drawtype = "normal",
-    visual_scale = 1.0,
-    tiles = {
-        "nv_stone.png"
-    },
-    paramtype2 = "facedir",
-    place_param2 = 8,
-})
-minetest.register_alias('mapgen_stone', 'nv_planetgen:stone')
-
-minetest.register_node('nv_planetgen:water_source', {
-    drawtype = "liquid",
-    visual_scale = 1.0,
-    tiles = {
-        "nv_water.png"
-    },
-    paramtype2 = "facedir",
-    place_param2 = 8,
-})
-minetest.register_alias('mapgen_water_source', 'nv_planetgen:water_source')
-
---[[
-Dictionary, maps node IDs to random texture rotation modulo.
-See 'pass_final.lua'. Sensible values are:
-    nil     No entry, random rotation disabled
-    1       Effectively equivalent to 'nil'
-    2       Rotate some blocks 90 deg around +Y vector
-    4       Rotate all blocks a random multiple of 90 deg around +Y vector
-    24      Rotate all blocks randomly around all axes
-Here, add random texture rotation around Y axis to dummy stone block
-]]--
-
-nv_planetgen.random_yrot_nodes = {
-    [minetest.get_content_id('nv_planetgen:stone')] = 4
-}
-
---[[
-Dictionary, maps node IDs to color param2 multiplier.
-See 'pass_final.lua'. Sensible values are:
-    nil     No entry, equivalent to 1
-    1       Useful for param2 = 'color'
-    4       Useful for param2 = 'color4dir'
-    8       Useful for param2 = 'colorwallmounted'
-    32      Useful for param2 = 'colorfacedir' or 'colordegrotate'
-Here, add random texture rotation around Y axis to dummy stone block
-]]--
-
-nv_planetgen.color_multiplier = {}
-
-nv_planetgen.register_all_nodes()

--- a/mods/nv_planetgen/mapgen.lua
+++ b/mods/nv_planetgen/mapgen.lua
@@ -34,7 +34,9 @@ function nv_planetgen.register_post_processing(callback)
 end
 
 local function planet_from_mapping(mapping)
-    local planet_dictionary = minetest.deserialize(minetest.get_mapgen_setting("nv_planetgen.planet_dictionary"))
+    local f = io.open(minetest.get_worldpath() .. "/nv_planetgen.planet_dictionary", "rt")
+    local planet_dictionary = minetest.deserialize(f:read())
+    f:close()
     local planet = planet_dictionary[mapping.seed]
     return planet
 end
@@ -170,7 +172,9 @@ local function mapgen_callback(VM, minp, maxp, blockseed)
     local not_generated_boxes = {{minp = minp, maxp = maxp}}
 
     -- Find mapping(s) for the generated region
-    local planet_mappings = minetest.deserialize(minetest.get_mapgen_setting("nv_planetgen.planet_mappings"))
+    local f = io.open(minetest.get_worldpath() .. "/nv_planetgen.planet_mappings", "rt")
+    local planet_mappings = minetest.deserialize(f:read())
+    f:close()
     for key, mapping in pairs(planet_mappings) do
         local commonmin = {
             x=max(minp.x, mapping.minp.x),

--- a/mods/nv_planetgen/nodetypes.lua
+++ b/mods/nv_planetgen/nodetypes.lua
@@ -10,7 +10,6 @@ such, you should perform the same changes in that file.
  # INDEX
     NODE TYPES
     REGISTRATION
-    VARIANT SELECTION
 ]]
 
 nv_planetgen.color_multiplier = {}
@@ -788,54 +787,4 @@ function nv_planetgen.register_all_nodes()
     register_liquid_nodes()
     register_icy_nodes()
     register_base_floral_nodes()
-end
-
---[[
- # VARIANT SELECTION
-]]
-
-function nv_planetgen.choose_planet_nodes_and_colors(planet)
-    local G = PcgRandom(planet.seed, planet.seed)
-    local stone_color = G:next(1, 16)
-    planet.raw_colors.stone = fnColorStone(stone_color)
-    planet.node_types.dust = minetest.get_content_id("nv_planetgen:dust" .. math.floor((stone_color - 1) / 8 + 1))
-    planet.color_dictionary[planet.node_types.dust] = (stone_color - 1) % 8
-    planet.node_types.sediment = minetest.get_content_id("nv_planetgen:sediment" .. math.floor((stone_color - 1) / 8 + 1))
-    planet.color_dictionary[planet.node_types.sediment] = (stone_color - 1) % 8
-    planet.node_types.gravel = minetest.get_content_id("nv_planetgen:gravel" .. math.floor((stone_color - 1) / 8 + 1))
-    planet.color_dictionary[planet.node_types.gravel] = (stone_color - 1) % 8
-    planet.node_types.stone = minetest.get_content_id("nv_planetgen:stone")
-    planet.color_dictionary[planet.node_types.stone] = stone_color - 1
-    if planet.atmosphere == "freezing" then
-        planet.node_types.liquid = minetest.get_content_id("nv_planetgen:hydrocarbon")
-        planet.raw_colors.liquid = {r = 113, g = 113, b = 113}
-    elseif planet.atmosphere == "scorching" then
-        planet.node_types.liquid = minetest.get_content_id("nv_planetgen:lava")
-        planet.raw_colors.liquid = {r = 255, g = 169, b = 0}
-    elseif gen_true_with_probability(G, planet.terrestriality + 0.18) then
-        local water_color = G:next(1, 24)
-        planet.node_types.liquid = minetest.get_content_id("nv_planetgen:water" .. water_color)
-        planet.raw_colors.liquid = fnColorWater(water_color)
-    else
-        local water_color = G:next(25, 32)
-        planet.node_types.liquid = minetest.get_content_id("nv_planetgen:water" .. water_color)
-        planet.raw_colors.liquid = fnColorWater(water_color)
-    end
-    planet.node_types.snow = minetest.get_content_id("nv_planetgen:snow")
-    planet.node_types.ice = minetest.get_content_id("nv_planetgen:ice")
-    local grass_color
-    if gen_true_with_probability(G, 1/2) then
-        grass_color = G:next(1, 32)
-    else
-        grass_color = G:next(33, 48)
-    end
-    planet.node_types.grass_soil = minetest.get_content_id("nv_planetgen:grass_soil" .. stone_color)
-    planet.color_dictionary[planet.node_types.grass_soil] = grass_color - 1
-    planet.raw_colors.grass = fnColorGrass(grass_color)
-    planet.node_types.grass = minetest.get_content_id("nv_planetgen:grass" .. math.floor((grass_color - 1) / 8 + 1))
-    planet.color_dictionary[planet.node_types.grass] = (grass_color - 1) % 8
-    planet.node_types.dry_grass = minetest.get_content_id("nv_planetgen:dry_grass" .. math.floor((grass_color - 1) / 8 + 1))
-    planet.color_dictionary[planet.node_types.dry_grass] = (grass_color - 1) % 8
-    planet.node_types.tall_grass = minetest.get_content_id("nv_planetgen:tall_grass" .. math.floor((grass_color - 1) / 8 + 1))
-    planet.color_dictionary[planet.node_types.tall_grass] = (grass_color - 1) % 8
 end

--- a/mods/nv_planetgen/pass_final.lua
+++ b/mods/nv_planetgen/pass_final.lua
@@ -13,6 +13,10 @@ and correct colors.
 function nv_planetgen.pass_final(
     minp_abs, maxp_abs, area, offset, A, A1, A2, mapping, planet, ground_buffer
 )
+    return
+    -- TODO: implement
+end
+function unused()
     local minpx, minpy, minpz = minp_abs.x, minp_abs.y, minp_abs.z
     local maxpx, maxpy, maxpz = maxp_abs.x, maxp_abs.y, maxp_abs.z
 

--- a/mods/nv_planetgen/pass_final.lua
+++ b/mods/nv_planetgen/pass_final.lua
@@ -13,10 +13,6 @@ and correct colors.
 function nv_planetgen.pass_final(
     minp_abs, maxp_abs, area, offset, A, A1, A2, mapping, planet, ground_buffer
 )
-    return
-    -- TODO: implement
-end
-function unused()
     local minpx, minpy, minpz = minp_abs.x, minp_abs.y, minp_abs.z
     local maxpx, maxpy, maxpz = maxp_abs.x, maxp_abs.y, maxp_abs.z
 
@@ -31,6 +27,13 @@ function unused()
     local offset_x, offset_y, offset_z = offset.x, offset.y, offset.z
 
     local G = PcgRandom(5683749)
+    
+    local f = io.open(minetest.get_worldpath() .. "/nv_planetgen.random_yrot_nodes", "rt")
+    local random_yrot_nodes = minetest.deserialize(f:read())
+    f:close()
+    f = io.open(minetest.get_worldpath() .. "/nv_planetgen.color_multiplier", "rt")
+    local color_multiplier = minetest.deserialize(f:read())
+    f:close()
 
     local base = area.MinEdge
     local extent = area:getExtent()
@@ -65,7 +68,7 @@ function unused()
                         end
 
                         -- Apply random texture rotation to all supported nodes
-                        local rot = nv_planetgen.random_yrot_nodes[A[i]]
+                        local rot = random_yrot_nodes[A[i]]
                         local param2 = A2[i]
                         if rot ~= nil then
                             param2 = G:next() % rot
@@ -77,7 +80,7 @@ function unused()
                         -- Apply palette color to all supported nodes
                         local color = planet.color_dictionary[A[i]]
                         if color ~= nil then
-                            local multiplier = nv_planetgen.color_multiplier[A[i]] or 1
+                            local multiplier = color_multiplier[A[i]] or 1
                             color = color * multiplier
                             param2 = param2 + color
                         end

--- a/mods/nv_planetgen/pass_structures.lua
+++ b/mods/nv_planetgen/pass_structures.lua
@@ -38,24 +38,6 @@ Structure format:
     custom      custom data to pass to the callback function
 ]]--
 
-local registered_structures = {}
-local function register_structure(seed, def)
-    registered_structures[seed] = registered_structures[seed] or {}
-    for n, structure in ipairs(registered_structures[seed]) do
-        if structure.order > def.order then
-            table.insert(registered_structures[seed], n, def)
-            break
-        end
-    end
-    table.insert(registered_structures[seed], def)
-end
-
-local structure_handlers = {}
--- The callback will get a seed and must return a list of structures
-function nv_planetgen.register_structure_handler(callback)
-    table.insert(structure_handlers, callback)
-end
-
 local function get_registered_structures(seed)
     registered_structures[seed] = {}
     for _, callback in ipairs(structure_handlers) do
@@ -73,6 +55,9 @@ end
 function nv_planetgen.pass_structures(
     minp_abs, maxp_abs, area, offset, A, A1, A2, mapping, planet, ground_buffer
 )
+    return
+    -- TODO: implement
+    --[[
     local seed = mapping.seed
     if registered_structures[seed] == nil then
         get_registered_structures(seed)
@@ -109,5 +94,5 @@ function nv_planetgen.pass_structures(
                 end
             end
         end
-    end
+    end]]--
 end

--- a/mods/nv_planetgen/pass_structures.lua
+++ b/mods/nv_planetgen/pass_structures.lua
@@ -38,12 +38,17 @@ Structure format:
     custom      custom data to pass to the callback function
 ]]--
 
+local registered_structures = {}
+nv_planetgen.registered_structures = registered_structures
+local structure_handlers = {}
+nv_planetgen.structure_handlers = structure_handlers
+
 local function get_registered_structures(seed)
     registered_structures[seed] = {}
     for _, callback in ipairs(structure_handlers) do
         local structures = callback(seed)
         for _, structure in ipairs(structures) do
-            register_structure(seed, structure)
+            nv_planetgen.register_structure(seed, structure)
         end
     end
 end
@@ -55,9 +60,6 @@ end
 function nv_planetgen.pass_structures(
     minp_abs, maxp_abs, area, offset, A, A1, A2, mapping, planet, ground_buffer
 )
-    return
-    -- TODO: implement
-    --[[
     local seed = mapping.seed
     if registered_structures[seed] == nil then
         get_registered_structures(seed)
@@ -94,5 +96,5 @@ function nv_planetgen.pass_structures(
                 end
             end
         end
-    end]]--
+    end
 end

--- a/mods/nv_ships/mapgen.lua
+++ b/mods/nv_ships/mapgen.lua
@@ -1,5 +1,7 @@
 local function post_processing_callback(minp, maxp, area, offset, A, A1, A2, mapping, planet, ground_buffer)
-    local players_list = minetest.deserialize(minetest.get_mapgen_setting("nv_ships.players_list"))
+    local f = io.open(minetest.get_worldpath() .. "/nv_ships.players_list", "rt")
+    local players_list = minetest.deserialize(f:read())
+    f:close()
     for name, player_data in pairs(players_list) do
         for index, ship in ipairs(player_data.ships) do
             --nv_ships.poll_ship_pos(ship)

--- a/mods/nv_ships/mapgen.lua
+++ b/mods/nv_ships/mapgen.lua
@@ -1,0 +1,33 @@
+local function post_processing_callback(minp, maxp, area, offset, A, A1, A2, mapping, planet, ground_buffer)
+    local players_list = minetest.deserialize(minetest.get_mapgen_setting("nv_ships.players_list"))
+    for name, player_data in pairs(players_list) do
+        for index, ship in ipairs(player_data.ships) do
+            --nv_ships.poll_ship_pos(ship)
+            if ship.pos ~= nil and ship.state == "node" then
+                local x_stride = ship.size.x
+                local y_stride = ship.size.y
+                for z_abs=math.max(minp.z, ship.pos.z),math.min(maxp.z, ship.pos.z + ship.size.z - 1),1 do
+                    for y_abs=math.max(minp.y, ship.pos.y),math.min(maxp.y, ship.pos.y + ship.size.y - 1),1 do
+                        for x_abs=math.max(minp.x, ship.pos.x),math.min(maxp.x, ship.pos.x + ship.size.x - 1),1 do
+                            local rel_pos = {
+                                x = x_abs - ship.pos.x,
+                                y = y_abs - ship.pos.y,
+                                z = z_abs - ship.pos.z
+                            }
+                            local k = rel_pos.z*y_stride*x_stride + rel_pos.y*x_stride + rel_pos.x + 1
+                            local i = area:index(x_abs, y_abs, z_abs)
+                            if ship.An[k] ~= "" then
+                                A[i] = minetest.get_content_id(ship.An[k])
+                                A2[i] = ship.A2[k]
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
+if nv_planetgen ~= nil then
+    nv_planetgen.register_post_processing(post_processing_callback)
+end

--- a/mods/nv_ships/ship.lua
+++ b/mods/nv_ships/ship.lua
@@ -29,7 +29,7 @@ A table of players, indexed by name. Each value contains the following fields:
     sound       Handle to the ship sound currently playing
 ]]--
 nv_ships.players_list = {}
-minetest.set_mapgen_setting("nv_ships.players_list", minetest.serialize(nv_ships.players_list))
+minetest.safe_file_write(minetest.get_worldpath() .. "/nv_ships.players_list", minetest.serialize(nv_ships.players_list))
 
 --[[
 Ship format:

--- a/mods/nv_ships/ship.lua
+++ b/mods/nv_ships/ship.lua
@@ -29,6 +29,7 @@ A table of players, indexed by name. Each value contains the following fields:
     sound       Handle to the ship sound currently playing
 ]]--
 nv_ships.players_list = {}
+minetest.set_mapgen_setting("nv_ships.players_list", minetest.serialize(nv_ships.players_list))
 
 --[[
 Ship format:

--- a/mods/nv_ships/ship_convert.lua
+++ b/mods/nv_ships/ship_convert.lua
@@ -171,7 +171,7 @@ function nv_ships.ship_to_entity(ship, player, remove)
     end
     ship.state = "entity"
     ship.pos = nil
-    minetest.set_mapgen_setting("nv_ships.players_list", minetest.serialize(nv_ships.players_list))
+    minetest.safe_file_write(minetest.get_worldpath() .. "/nv_ships.players_list", minetest.serialize(nv_ships.players_list))
     return ship
 end
 
@@ -341,5 +341,5 @@ function nv_ships.ship_to_node(ship, player, pos)
     if player then
         nv_ships.remove_ship_entity(player)
     end
-    minetest.set_mapgen_setting("nv_ships.players_list", minetest.serialize(nv_ships.players_list))
+    minetest.safe_file_write(minetest.get_worldpath() .. "/nv_ships.players_list", minetest.serialize(nv_ships.players_list))
 end

--- a/mods/nv_ships/ship_convert.lua
+++ b/mods/nv_ships/ship_convert.lua
@@ -7,6 +7,10 @@ forms of a ship, as well as some related operations.
     TO NODE
 ]]--
 
+if minetest.register_mapgen_script then
+    minetest.register_mapgen_script(minetest.get_modpath("nv_ships") .. "/mapgen.lua")
+end
+
 --[[
  # TO ENTITY
 ]]--
@@ -167,6 +171,7 @@ function nv_ships.ship_to_entity(ship, player, remove)
     end
     ship.state = "entity"
     ship.pos = nil
+    minetest.set_mapgen_setting("nv_ships.players_list", minetest.serialize(nv_ships.players_list))
     return ship
 end
 
@@ -336,37 +341,5 @@ function nv_ships.ship_to_node(ship, player, pos)
     if player then
         nv_ships.remove_ship_entity(player)
     end
-end
-
-local function post_processing_callback(minp, maxp, area, offset, A, A1, A2, mapping, planet, ground_buffer)
-    for name, player_data in pairs(nv_ships.players_list) do
-        for index, ship in ipairs(player_data.ships) do
-            nv_ships.poll_ship_pos(ship)
-            if ship.pos ~= nil and ship.state == "node" then
-                local x_stride = ship.size.x
-                local y_stride = ship.size.y
-                for z_abs=math.max(minp.z, ship.pos.z),math.min(maxp.z, ship.pos.z + ship.size.z - 1),1 do
-                    for y_abs=math.max(minp.y, ship.pos.y),math.min(maxp.y, ship.pos.y + ship.size.y - 1),1 do
-                        for x_abs=math.max(minp.x, ship.pos.x),math.min(maxp.x, ship.pos.x + ship.size.x - 1),1 do
-                            local rel_pos = {
-                                x = x_abs - ship.pos.x,
-                                y = y_abs - ship.pos.y,
-                                z = z_abs - ship.pos.z
-                            }
-                            local k = rel_pos.z*y_stride*x_stride + rel_pos.y*x_stride + rel_pos.x + 1
-                            local i = area:index(x_abs, y_abs, z_abs)
-                            if ship.An[k] ~= "" then
-                                A[i] = minetest.get_content_id(ship.An[k])
-                                A2[i] = ship.A2[k]
-                            end
-                        end
-                    end
-                end
-            end
-        end
-    end
-end
-
-if nv_planetgen ~= nil then
-    nv_planetgen.register_post_processing(post_processing_callback)
+    minetest.set_mapgen_setting("nv_ships.players_list", minetest.serialize(nv_ships.players_list))
 end

--- a/mods/nv_universe/init.lua
+++ b/mods/nv_universe/init.lua
@@ -36,6 +36,9 @@ dofile(minetest.get_modpath("nv_universe") .. "/allocation.lua")
 dofile(minetest.get_modpath("nv_universe") .. "/sky.lua")
 dofile(minetest.get_modpath("nv_universe") .. "/menu.lua")
 dofile(minetest.get_modpath("nv_universe") .. "/storage.lua")
+if minetest.register_mapgen_script then
+    minetest.register_mapgen_script(minetest.get_modpath("nv_universe") .. "/mapgen.lua")
+end
 
 --[[
  # PLAYER LIST
@@ -261,30 +264,3 @@ local function dignode_callback(pos, oldnode, digger)
 end
 
 minetest.register_on_dignode(dignode_callback)
-
-local function post_processing_callback(minp, maxp, area, offset, A, A1, A2, mapping, planet, ground_buffer)
-    if not nv_universe.dug[false] then
-        return
-    end
-    for p, cur in pairs(nv_universe.dug[false]) do
-        if p == planet.seed then
-            for y, cur2 in pairs(cur) do
-                if y - offset.y >= minp.y and y - offset.y <= maxp.y then
-                    for z, cur3 in pairs(cur2) do
-                        if z >= minp.z and z <= maxp.z then
-                            for x, t in pairs(cur3) do
-                                local i = area:index(x, y - offset.y, z)
-                                local def = minetest.registered_nodes[minetest.get_name_from_content_id(A[i])]
-                                if not def.nv_managed then
-                                    A[i] = minetest.CONTENT_AIR
-                                end
-                            end
-                        end
-                    end
-                end
-            end
-        end
-    end
-end
-
-nv_planetgen.register_post_processing(post_processing_callback)

--- a/mods/nv_universe/init.lua
+++ b/mods/nv_universe/init.lua
@@ -38,6 +38,8 @@ dofile(minetest.get_modpath("nv_universe") .. "/menu.lua")
 dofile(minetest.get_modpath("nv_universe") .. "/storage.lua")
 if minetest.register_mapgen_script then
     minetest.register_mapgen_script(minetest.get_modpath("nv_universe") .. "/mapgen.lua")
+else
+    dofile(minetest.get_modpath("nv_universe") .. "/mapgen.lua")
 end
 
 --[[

--- a/mods/nv_universe/mapgen.lua
+++ b/mods/nv_universe/mapgen.lua
@@ -1,5 +1,7 @@
 local function post_processing_callback(minp, maxp, area, offset, A, A1, A2, mapping, planet, ground_buffer)
-    local dug = minetest.deserialize(minetest.get_mapgen_setting("nv_universe.dug"))
+    local f = io.open(minetest.get_worldpath() .. "/nv_universe.dug", "rt")
+    local dug = minetest.deserialize(f:read())
+    f:close()
     if not dug[false] then
         return
     end

--- a/mods/nv_universe/mapgen.lua
+++ b/mods/nv_universe/mapgen.lua
@@ -1,0 +1,27 @@
+local function post_processing_callback(minp, maxp, area, offset, A, A1, A2, mapping, planet, ground_buffer)
+    local dug = minetest.deserialize(minetest.get_mapgen_setting("nv_universe.dug"))
+    if not dug[false] then
+        return
+    end
+    for p, cur in pairs(dug[false]) do
+        if p == planet.seed then
+            for y, cur2 in pairs(cur) do
+                if y - offset.y >= minp.y and y - offset.y <= maxp.y then
+                    for z, cur3 in pairs(cur2) do
+                        if z >= minp.z and z <= maxp.z then
+                            for x, t in pairs(cur3) do
+                                local i = area:index(x, y - offset.y, z)
+                                local def = minetest.registered_nodes[minetest.get_name_from_content_id(A[i])]
+                                if not def.nv_managed then
+                                    A[i] = minetest.CONTENT_AIR
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
+nv_planetgen.register_post_processing(post_processing_callback)

--- a/mods/nv_universe/storage.lua
+++ b/mods/nv_universe/storage.lua
@@ -109,18 +109,8 @@ function nv_universe.load_global_state()
                     nv_universe.layers[index][key] = (value == "true")
                 elseif key == "planet" or key == "n_players" then
                     nv_universe.layers[index][key] = tonumber(value)
-                elseif key == "areas" then
-                    local n_areas = math.floor(#value / 18)
-                    nv_universe.layers[index][key] = {}
-                    for n=1,n_areas-1,1 do
-                        local minp_str = value:sub(1+n*18,9+n*18)
-                        local maxp_str = value:sub(10+n*18,18+n*18)
-                        local new_area = {
-                            minp = decode_vs18(minp_str),
-                            maxp = decode_vs18(minp_str)
-                        }
-                        table.insert(nv_universe.layers[index][key], new_area)
-                    end
+                elseif key == "mapping" then
+                    nv_universe.layers[index][key] = tonumber(value)
                 end
             elseif name:sub(1, 1) == "p" then
                 nv_universe.planets[index] = nv_universe.planets[index] or {}
@@ -173,16 +163,9 @@ function nv_universe.store_global_state()
     local meta = global_meta
     for index, value in pairs(nv_universe.layers) do
         for key, val in pairs(value) do
-            if key == "areas" then
+            if key == "mapping" then
                 local array = {}
-                for _, area in ipairs(val) do
-                    encode_s18(array, area.minp.x)
-                    encode_s18(array, area.minp.y)
-                    encode_s18(array, area.minp.z)
-                    encode_s18(array, area.maxp.x)
-                    encode_s18(array, area.maxp.y)
-                    encode_s18(array, area.maxp.z)
-                end
+                encode_s18(array, val)
                 written_table[string.format("nv_universe:l%d_%s", index, key)] = table.concat(array)
             else
                 written_table[string.format("nv_universe:l%d_%s", index, key)] = tostring(val)

--- a/mods/nv_universe/util.lua
+++ b/mods/nv_universe/util.lua
@@ -8,6 +8,7 @@ then by Y, then by Z, then by X. Each leaf node only contains 'true'.
 ]]--
 
 nv_universe.dug = {}
+minetest.set_mapgen_setting("nv_universe.dug", minetest.serialize(nv_universe.dug))
 
 function nv_universe.mark_dug_node(in_space, planet, x, y, z)
     if nv_universe.dug[in_space] == nil then
@@ -29,6 +30,7 @@ function nv_universe.mark_dug_node(in_space, planet, x, y, z)
     if cur[x] == nil then
         cur[x] = true
     end
+    minetest.set_mapgen_setting("nv_universe.dug", minetest.serialize(nv_universe.dug))
 end
 
 function nv_universe.sRGB_to_string(sRGB)

--- a/mods/nv_universe/util.lua
+++ b/mods/nv_universe/util.lua
@@ -8,7 +8,7 @@ then by Y, then by Z, then by X. Each leaf node only contains 'true'.
 ]]--
 
 nv_universe.dug = {}
-minetest.set_mapgen_setting("nv_universe.dug", minetest.serialize(nv_universe.dug))
+minetest.safe_file_write(minetest.get_worldpath() .. "/nv_universe.dug", minetest.serialize(nv_universe.dug))
 
 function nv_universe.mark_dug_node(in_space, planet, x, y, z)
     if nv_universe.dug[in_space] == nil then
@@ -30,7 +30,7 @@ function nv_universe.mark_dug_node(in_space, planet, x, y, z)
     if cur[x] == nil then
         cur[x] = true
     end
-    minetest.set_mapgen_setting("nv_universe.dug", minetest.serialize(nv_universe.dug))
+    minetest.safe_file_write(minetest.get_worldpath() .. "/nv_universe.dug", minetest.serialize(nv_universe.dug))
 end
 
 function nv_universe.sRGB_to_string(sRGB)


### PR DESCRIPTION
This adds support for the new async mapgen API, which allows mods to perform custom mapgen off the main thread. This will avoid blocking the main thread, which will fix the current struggles with manouvering spaceships; additionally, if the engine is configured to use multiple threads for terrain generation, Nodeverse will now be able to fully utilize those threads.

I'll merge this PR, but a release containing the changes will not be published until a new version of the engine is published with the new API.